### PR TITLE
Add Font-Weight

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 ```sh
 cd planningcenter.design
+yarn install
 yarn develop
 ```
 

--- a/src/articles/font-weight.md
+++ b/src/articles/font-weight.md
@@ -1,0 +1,26 @@
+---
+path: "/font-weight"
+date: "2021-01-15"
+title: "Font Weight"
+category: "systems"
+---
+
+## General guidelines
+
+**NOTE**: These are suggestions, not concrete rules&mdash;context, contrast, and color play a vital role in which weight is best for specific scenarios.
+
+### Normal / min
+- 400 is recommended for standard body text and the minimum overall used weight.
+
+### Strong / max
+- 700 is recommended for strong body text and the maximum overall used weight.
+
+### Additional weights
+- 500, 600 may be used on a case-by-case basis, especially in smaller titles where 700 may feel too heavy.
+
+
+
+## Resources
+
+- [Audit Spreadsheet](https://docs.google.com/spreadsheets/d/1WeNL24OXztjXjOGKFXxuVAUyYXDYHef-TAg-AB6AdzA/edit?usp=sharing)
+- [Audit Figma](https://www.figma.com/file/zelVKXlL9olEtO4sdxNqF4/Font-weight-audit?node-id=0%3A1)

--- a/src/articles/font-weight.md
+++ b/src/articles/font-weight.md
@@ -18,8 +18,6 @@ category: "systems"
 ### Additional weights
 - 500, 600 may be used on a case-by-case basis, especially in smaller titles where 700 may feel too heavy.
 
-
-
 ## Resources
 
 - [Audit Spreadsheet](https://docs.google.com/spreadsheets/d/1WeNL24OXztjXjOGKFXxuVAUyYXDYHef-TAg-AB6AdzA/edit?usp=sharing)


### PR DESCRIPTION
Adds general guidelines for using font-weight.

![image](https://user-images.githubusercontent.com/8367129/104790606-8a0a6480-574c-11eb-91c4-677534b3b3b4.png)

---

I also added `yarn install` to the readme so no one makes the same mistake I did. At first I thought I needed to manually install gatsby when I got `Gatsby: command not found`, but just running `yarn install` was enough. 😄 